### PR TITLE
Makefile generation fix and improvements 

### DIFF
--- a/R/fun_makefile_create.R
+++ b/R/fun_makefile_create.R
@@ -11,13 +11,12 @@ deepstate_create_makefile <-function(package,fun_name){
   fun_path <- file.path(test_path,fun_name)
   log_file_path <- file.path(fun_path,paste0(fun_name,"_log"))
 
-  makefile.name <-paste0("Makefile")
   test_harness <- paste0(fun_name,"_DeepState_TestHarness")
-  makefile_path <- file.path(fun_path,makefile.name)
-  makefile.name.o <-paste0(test_harness,".o")
-  makefile.name.cpp <-paste0(test_harness,".cpp")
-  makefile.o_path<-file.path(fun_path,makefile.name.o)
-  makefile.cpp_path<-file.path(fun_path,makefile.name.cpp)
+  makefile_path <- file.path(fun_path, "Makefile")
+  test_harness.o <- paste0(test_harness,".o")
+  test_harness.cpp <- paste0(test_harness,".cpp")
+  test_harness.o_path <- file.path(fun_path,test_harness.o)
+  test_harness.cpp_path <- file.path(fun_path,test_harness.cpp)
   test_harness_path <- file.path(fun_path,test_harness)
   file.create(makefile_path, recursive=TRUE)
 
@@ -70,10 +69,10 @@ deepstate_create_makefile <-function(package,fun_name){
   objs.add <- file.path(package,paste0("src/", fun_name, ".o"))
  
   # Makefile rules : compile lines
-  write_to_file<-paste0(write_to_file, "\n\n", test_harness_path, " : ", makefile.o_path)
-  write_to_file<-paste0(write_to_file, "\n\t", "clang++ -g -o ", test_harness_path, " ", makefile.o_path, " ${CPPFLAGS} ", " ${LDFLAGS} ", " ${LDLIBS} ", obj.file.path) #," ",objs.add)
-  write_to_file<-paste0(write_to_file, "\n\n", makefile.o_path, " : ", makefile.cpp_path)
-  write_to_file<-paste0(write_to_file, "\n\t", "clang++ -g -c ", " ${CPPFLAGS} ", makefile.cpp_path, " -o ", makefile.o_path)
+  write_to_file<-paste0(write_to_file, "\n\n", test_harness_path, " : ", test_harness.o_path)
+  write_to_file<-paste0(write_to_file, "\n\t", "clang++ -g -o ", test_harness_path, " ", test_harness.o_path, " ${CPPFLAGS} ", " ${LDFLAGS} ", " ${LDLIBS} ", obj.file.path) #," ",objs.add)
+  write_to_file<-paste0(write_to_file, "\n\n", test_harness.o_path, " : ", test_harness.cpp_path)
+  write_to_file<-paste0(write_to_file, "\n\t", "clang++ -g -c ", " ${CPPFLAGS} ", test_harness.cpp_path, " -o ", test_harness.o_path)
 
   write(write_to_file, makefile_path, append=TRUE)
 }

--- a/R/fun_makefile_create.R
+++ b/R/fun_makefile_create.R
@@ -22,7 +22,7 @@ deepstate_create_makefile <-function(package,fun_name){
   path_home <-paste0("R_HOME=",R.home())
   path_include <-paste0("R_INCLUDE=",R.home("include"))
   path_lib <-paste0("R_LIB=",R.home("lib"))
-  write_to_file<-paste0(write_to_file,path_home,"\n",path_include,"\n")
+  write_to_file<-paste0(write_to_file,path_home,"\n",path_include,"\n",path_lib,"\n")
   insts.path <- "${HOME}"
   deepstate.path <- file.path(insts.path,".RcppDeepState")
   master <- file.path(deepstate.path,"deepstate-master")

--- a/R/fun_makefile_create.R
+++ b/R/fun_makefile_create.R
@@ -9,6 +9,7 @@ deepstate_create_makefile <-function(package,fun_name){
   #p <- nc::capture_all_str(list.paths$remain_path,val=".+/",folder=".+/",packagename=".*")
   test_path <- file.path(inst_path,"testfiles")
   fun_path <- file.path(test_path,fun_name)
+  log_file_path <- file.path(fun_path,paste0(fun_name,"_log"))
 
   makefile.name <-paste0("Makefile")
   test_harness <- paste0(fun_name,"_DeepState_TestHarness")
@@ -22,35 +23,58 @@ deepstate_create_makefile <-function(package,fun_name){
   path_home <-paste0("R_HOME=",R.home())
   path_include <-paste0("R_INCLUDE=",R.home("include"))
   path_lib <-paste0("R_LIB=",R.home("lib"))
-  write_to_file<-paste0(path_home,"\n",path_include,"\n",path_lib,"\n")
-  insts.path <- "${HOME}"
-  deepstate.path <- file.path(insts.path,".RcppDeepState")
-  master <- file.path(deepstate.path,"deepstate-master")
-  deepstate.build <- file.path(master,"build")
-  deepstate.header <- file.path(master,"src/include")
-  flags <- paste0("COMMON_FLAGS = ",makefile.o_path," -I",
-                  system.file("include",package="RcppDeepState")," -I",deepstate.build," -I",
-                  deepstate.header," -L",system.file("lib", package="RInside"),
-                  " -Wl,-rpath=",system.file("lib", package="RInside"),
-                  " -L${R_LIB} -Wl,-rpath=${R_LIB}"," -L",deepstate.build,
-                  " -Wl,-rpath=",deepstate.build," -lR -lRInside -ldeepstate")
-  write_to_file<-paste0(write_to_file,flags)
-  log_file_path <- file.path(fun_path,paste0(fun_name,"_log"))
+  write_to_file <- paste0(path_home,"\n",path_include,"\n",path_lib,"\n\n")
+  
+  # include and lib path locations
+  rcpp_include <- system.file("include", package="RcppDeepState")
+  rcppdeepstate_include <- system.file("include", package="Rcpp")
+  rcpparmadillo_include <- system.file("include", package="RcppArmadillo")
+  rinside_include <- system.file("include", package="RInside")
+  deepstate_path <- file.path("${HOME}", ".RcppDeepState", "deepstate-master")
+  deepstate_build <- file.path(deepstate_path, "build")
+  deepstate_include <- file.path(deepstate_path, "src", "include")
+  qs_include <- system.file("include", package="qs")
+  rinside_lib <- system.file("lib", package="RInside")
+
+  # CPPFLAGS : headers inclusion
+  compiler_cppflags <- paste0("-I", rcpp_include) 
+  compiler_cppflags <- paste(compiler_cppflags, paste0("-I", rcppdeepstate_include)) 
+  compiler_cppflags <- paste(compiler_cppflags, paste0("-I", rcpparmadillo_include)) 
+  compiler_cppflags <- paste(compiler_cppflags, paste0("-I", rinside_include)) 
+  compiler_cppflags <- paste(compiler_cppflags, paste0("-I", deepstate_build))
+  compiler_cppflags <- paste(compiler_cppflags, paste0("-I", deepstate_include)) 
+  compiler_cppflags <- paste(compiler_cppflags, paste0("-I", qs_include)) 
+  compiler_cppflags <- paste(compiler_cppflags, paste0("-I", "${R_INCLUDE}"))
+  write_to_file <- paste0(write_to_file, "CPPFLAGS=",compiler_cppflags, "\n")
+
+  # LDFLAGS : libs inclusion
+  compiler_ldflags <- paste0("-L", rinside_lib, " -Wl,-rpath=", rinside_lib) 
+  compiler_ldflags <- paste(compiler_ldflags, "-L${R_LIB} -Wl,-rpath=${R_LIB}")
+  compiler_ldflags <- paste(compiler_ldflags, paste0("-L", deepstate_build, " -Wl,-rpath=", deepstate_build))
+  write_to_file <- paste0(write_to_file, "LDFLAGS=", compiler_ldflags, "\n")
+
+  # LDLIBS : library flags for the linker
+  compiler_ldlibs <- paste("-lR", "-lRInside", "-ldeepstate")
+  write_to_file <- paste0(write_to_file, "LDLIBS=",compiler_ldlibs, "\n\n")
+
+  # compiler line
   write_to_file<-paste0(write_to_file,"\n\n",test_harness_path," : ",makefile.o_path)
-  compile.line <- paste0("\n\t","clang++ -g -o ",test_harness_path," ${COMMON_FLAGS} ","-I${R_INCLUDE} -I", system.file("include", package="Rcpp")," -I",system.file("include", package="RcppArmadillo")," -I",deepstate.header," ")
+  compile.line <- paste0("\n\t","clang++ -g -o ",test_harness_path," ${CPPFLAGS} ", " ${LDFLAGS} ", " ${LDLIBS} ")
   install.packages(setdiff(basename(package), rownames(installed.packages())))
+  
   obj.file.list <-Sys.glob(file.path(package,"src/*.so"))
   obj.file.path <- obj.file.list
   if(length(obj.file.list) <= 0){
     obj.file.path<-file.path(package,"src/*.cpp")  
   }
   objs.add <-file.path(package,paste0("src/",fun_name,".o"))
-  write_to_file<-paste0(write_to_file,compile.line,obj.file.path)#," ",objs.add)
+  write_to_file<-paste0(write_to_file, compile.line, obj.file.path)#," ",objs.add)
+
   dir.create(file.path(fun_path,paste0(fun_name,"_output")), showWarnings = FALSE)
+
   #write_to_file<-paste0(write_to_file,"\n\t","cd ",paste0("/home/",p$val,"testfiles","/",p$packagename)," && ","./",test_harness," --fuzz")
   write_to_file<-paste0(write_to_file,"\n\n",makefile.o_path," : ",makefile.cpp_path)
-  write_to_file<-paste0(write_to_file,"\n\t","clang++ -g -I${R_INCLUDE} -I", system.file("include", package="Rcpp"),
-                        " -I",system.file("include", package="RcppArmadillo")," -I",system.file("include", package="qs")," -I",system.file("include", package="RInside"),
-                        " -I",system.file("include",package="RcppDeepState")," ",makefile.cpp_path," -o ",makefile.o_path," -c")
+  write_to_file<-paste0(write_to_file,"\n\t","clang++ -g -c ", " ${CPPFLAGS} ", makefile.cpp_path," -o ", makefile.o_path)
+
   write(write_to_file,makefile_path,append=TRUE)
 }

--- a/R/fun_makefile_create.R
+++ b/R/fun_makefile_create.R
@@ -69,10 +69,10 @@ deepstate_create_makefile <-function(package,fun_name){
   objs.add <- file.path(package,paste0("src/", fun_name, ".o"))
  
   # Makefile rules : compile lines
+  write_to_file<-paste0(write_to_file, "\n\n", test_harness_path, " : ", test_harness.o_path)
+  write_to_file<-paste0(write_to_file, "\n\t", "clang++ -g ", test_harness.o_path, " ${CPPFLAGS} ", " ${LDFLAGS} ", " ${LDLIBS} ", obj.file.path, " -o ", test_harness_path) #," ",objs.add)
   write_to_file<-paste0(write_to_file, "\n\n", test_harness.o_path, " : ", test_harness.cpp_path)
   write_to_file<-paste0(write_to_file, "\n\t", "clang++ -g -c ", " ${CPPFLAGS} ", test_harness.cpp_path, " -o ", test_harness.o_path)
-  write_to_file<-paste0(write_to_file, "\n\n", test_harness_path, " : ", test_harness.o_path)
-  write_to_file<-paste0(write_to_file, "\n\t", "clang++ -g -o ", test_harness_path, " ", test_harness.o_path, " ${CPPFLAGS} ", " ${LDFLAGS} ", " ${LDLIBS} ", obj.file.path) #," ",objs.add)
   
   write(write_to_file, makefile_path, append=TRUE)
 }

--- a/R/fun_makefile_create.R
+++ b/R/fun_makefile_create.R
@@ -9,7 +9,7 @@ deepstate_create_makefile <-function(package,fun_name){
   #p <- nc::capture_all_str(list.paths$remain_path,val=".+/",folder=".+/",packagename=".*")
   test_path <- file.path(inst_path,"testfiles")
   fun_path <- file.path(test_path,fun_name)
-  write_to_file <- ""
+
   makefile.name <-paste0("Makefile")
   test_harness <- paste0(fun_name,"_DeepState_TestHarness")
   makefile_path <- file.path(fun_path,makefile.name)
@@ -22,7 +22,7 @@ deepstate_create_makefile <-function(package,fun_name){
   path_home <-paste0("R_HOME=",R.home())
   path_include <-paste0("R_INCLUDE=",R.home("include"))
   path_lib <-paste0("R_LIB=",R.home("lib"))
-  write_to_file<-paste0(write_to_file,path_home,"\n",path_include,"\n",path_lib,"\n")
+  write_to_file<-paste0(path_home,"\n",path_include,"\n",path_lib,"\n")
   insts.path <- "${HOME}"
   deepstate.path <- file.path(insts.path,".RcppDeepState")
   master <- file.path(deepstate.path,"deepstate-master")

--- a/R/fun_makefile_create.R
+++ b/R/fun_makefile_create.R
@@ -69,10 +69,10 @@ deepstate_create_makefile <-function(package,fun_name){
   objs.add <- file.path(package,paste0("src/", fun_name, ".o"))
  
   # Makefile rules : compile lines
-  write_to_file<-paste0(write_to_file, "\n\n", test_harness_path, " : ", test_harness.o_path)
-  write_to_file<-paste0(write_to_file, "\n\t", "clang++ -g -o ", test_harness_path, " ", test_harness.o_path, " ${CPPFLAGS} ", " ${LDFLAGS} ", " ${LDLIBS} ", obj.file.path) #," ",objs.add)
   write_to_file<-paste0(write_to_file, "\n\n", test_harness.o_path, " : ", test_harness.cpp_path)
   write_to_file<-paste0(write_to_file, "\n\t", "clang++ -g -c ", " ${CPPFLAGS} ", test_harness.cpp_path, " -o ", test_harness.o_path)
-
+  write_to_file<-paste0(write_to_file, "\n\n", test_harness_path, " : ", test_harness.o_path)
+  write_to_file<-paste0(write_to_file, "\n\t", "clang++ -g -o ", test_harness_path, " ", test_harness.o_path, " ${CPPFLAGS} ", " ${LDFLAGS} ", " ${LDLIBS} ", obj.file.path) #," ",objs.add)
+  
   write(write_to_file, makefile_path, append=TRUE)
 }

--- a/R/fun_makefile_create.R
+++ b/R/fun_makefile_create.R
@@ -21,6 +21,7 @@ deepstate_create_makefile <-function(package,fun_name){
   file.create(makefile_path, recursive=TRUE)
   path_home <-paste0("R_HOME=",R.home())
   path_include <-paste0("R_INCLUDE=",R.home("include"))
+  path_lib <-paste0("R_LIB=",R.home("lib"))
   write_to_file<-paste0(write_to_file,path_home,"\n",path_include,"\n")
   insts.path <- "${HOME}"
   deepstate.path <- file.path(insts.path,".RcppDeepState")
@@ -31,7 +32,7 @@ deepstate_create_makefile <-function(package,fun_name){
                   system.file("include",package="RcppDeepState")," -I",deepstate.build," -I",
                   deepstate.header," -L",system.file("lib", package="RInside"),
                   " -Wl,-rpath=",system.file("lib", package="RInside"),
-                  " -L${R_HOME}/lib -Wl,-rpath=${R_HOME}/lib"," -L",deepstate.build,
+                  " -L${R_LIB} -Wl,-rpath=${R_LIB}"," -L",deepstate.build,
                   " -Wl,-rpath=",deepstate.build," -lR -lRInside -ldeepstate")
   write_to_file<-paste0(write_to_file,flags)
   log_file_path <- file.path(fun_path,paste0(fun_name,"_log"))

--- a/R/fun_makefile_create.R
+++ b/R/fun_makefile_create.R
@@ -19,8 +19,9 @@ deepstate_create_makefile <-function(package,fun_name){
   makefile.cpp_path<-file.path(fun_path,makefile.name.cpp)
   test_harness_path <- file.path(fun_path,test_harness)
   file.create(makefile_path, recursive=TRUE)
-  path <-paste("R_HOME=",dirname(R.home('include')))
-  write_to_file<-paste0(write_to_file,path,"\n")
+  path_home <-paste0("R_HOME=",R.home())
+  path_include <-paste0("R_INCLUDE=",R.home("include"))
+  write_to_file<-paste0(write_to_file,path_home,"\n",path_include,"\n")
   insts.path <- "${HOME}"
   deepstate.path <- file.path(insts.path,".RcppDeepState")
   master <- file.path(deepstate.path,"deepstate-master")
@@ -35,7 +36,7 @@ deepstate_create_makefile <-function(package,fun_name){
   write_to_file<-paste0(write_to_file,flags)
   log_file_path <- file.path(fun_path,paste0(fun_name,"_log"))
   write_to_file<-paste0(write_to_file,"\n\n",test_harness_path," : ",makefile.o_path)
-  compile.line <- paste0("\n\t","clang++ -g -o ",test_harness_path," ${COMMON_FLAGS} ","-I${R_HOME}/include -I", system.file("include", package="Rcpp")," -I",system.file("include", package="RcppArmadillo")," -I",deepstate.header," ")
+  compile.line <- paste0("\n\t","clang++ -g -o ",test_harness_path," ${COMMON_FLAGS} ","-I${R_INCLUDE} -I", system.file("include", package="Rcpp")," -I",system.file("include", package="RcppArmadillo")," -I",deepstate.header," ")
   install.packages(setdiff(basename(package), rownames(installed.packages())))
   obj.file.list <-Sys.glob(file.path(package,"src/*.so"))
   obj.file.path <- obj.file.list
@@ -47,7 +48,7 @@ deepstate_create_makefile <-function(package,fun_name){
   dir.create(file.path(fun_path,paste0(fun_name,"_output")), showWarnings = FALSE)
   #write_to_file<-paste0(write_to_file,"\n\t","cd ",paste0("/home/",p$val,"testfiles","/",p$packagename)," && ","./",test_harness," --fuzz")
   write_to_file<-paste0(write_to_file,"\n\n",makefile.o_path," : ",makefile.cpp_path)
-  write_to_file<-paste0(write_to_file,"\n\t","clang++ -g -I${R_HOME}/include -I", system.file("include", package="Rcpp"),
+  write_to_file<-paste0(write_to_file,"\n\t","clang++ -g -I${R_INCLUDE} -I", system.file("include", package="Rcpp"),
                         " -I",system.file("include", package="RcppArmadillo")," -I",system.file("include", package="qs")," -I",system.file("include", package="RInside"),
                         " -I",system.file("include",package="RcppDeepState")," ",makefile.cpp_path," -o ",makefile.o_path," -c")
   write(write_to_file,makefile_path,append=TRUE)


### PR DESCRIPTION
After some checks I found that there was a problem in the Makefile generation procedure. In particular in the method `deepstate_create_makefile` of the file `R/fun_makefile_create.R` at line *22*
```R
path <- paste("R_HOME=",dirname(R.home('include')))
```
In some particular systems the `include` directory is not located in the home directory retrieved with the command `R.home()`. In order to correctly get the `include` directory, we should avoid a manual concatenation of string and use the proper function `R.home("include")`.

#### My case example
I found that this error occurs in all the ArchLinux based systems, in fact by checking the R installation procedure of the R package on the [AUR](https://archlinux.org/packages/extra/x86_64/r/)(Arch linux user repository for packages) we can see that a directory `/usr/lib/R` is created for the R home directory and the directory `/usr/include/R` is created for the R include files.
If the system is affected by this problem can be quickly determined by starting a working R environment and running the following commands
```R
R.home()
R.home("include")
```
If the latter returns a sub-directory of the directory returned by the first command, the problem may not arise. The problem will almost certainly occur if the second directory is not a sub-directory of the first one.