### PR TITLE
Override default Makevars

### DIFF
--- a/R/pkg_harness_create.R
+++ b/R/pkg_harness_create.R
@@ -27,8 +27,9 @@ deepstate_pkg_create<-function(package_path){
     makevars_file <- file.path(package_path, "src", "Makevars")
     makevars_content <- "PKG_CXXFLAGS += -g "
     write(makevars_content, makevars_file, append=FALSE)
-    
+
     system(paste0("R CMD INSTALL ",package_path),intern = FALSE,ignore.stderr =TRUE,ignore.stdout = TRUE)
+    unlink(makevars_file, recursive = FALSE)
   }
 
   if(!(file.exists("~/.RcppDeepState/deepstate-master/build/libdeepstate32.a") &&

--- a/R/pkg_harness_create.R
+++ b/R/pkg_harness_create.R
@@ -20,6 +20,9 @@ deepstate_pkg_create<-function(package_path){
   packagename <- basename(package_path)
   unlink(test_path, recursive = TRUE)
   if(!file.exists(file.path(package_path,"src/*.so"))){
+    makevars_file <- file.path(package_path, "src", "Makevars")
+    makevars_content <- "PKG_CXXFLAGS += -g "
+    write(makevars_content, makevars_file, append=FALSE)
     system(paste0("R CMD INSTALL ",package_path),intern = FALSE,ignore.stderr =TRUE,ignore.stdout = TRUE)
   }
   if(!(file.exists("~/.RcppDeepState/deepstate-master/build/libdeepstate32.a") &&


### PR DESCRIPTION
# Description
On some Linux based platforms, when installing a library using the `R CMD INSTALL` command, the binaries in the `src` folder are compiled omitting the `-g` parameter. The generated shared object for the library is missing debug symbols. 

When installing a library using the `R CMD INSTALL` command on some Linux systems, the binaries in the `src` folder are built without the `-g` flag. The result is that debug symbols are missing from the library's created shared object.

When RcppDeepState and, in particular, Valgrind are used to evaluate such a package, the outcome is an empty table from the `deepstate_harness_analyze_pkg` function.
There appears to be no error, from the fuzz testing analysis. However, a closer look at the resulting XML file reveals some errors found by Valgrind: the problem is that the errors are related to the shared object file rather than the original function. 

Fixes #2

# Solution
The solution is to override the current `Makevars` file in order to set the additional pre processor option `-g` to the compilation procedure run by the `R CMD INSTALL` command. The right method to accomplish this, as specified on the R project [documentation page](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Using-Makevars), is to create `Makevars` file in the package's `src` folder before running the installation command.

The function `deepstate_pkg_create` in the `pkg_harness_create.R` file in RcppDeepState runs the `R CMD INSTALL`. The goal of the solution is to intercept this system shell call and produce the `Makevars` file before the compilation begins. 