### PR TITLE
Rcpp string support

### DIFF
--- a/R/fun_harness_create.R
+++ b/R/fun_harness_create.R
@@ -152,7 +152,7 @@ deepstate_fun_create<-function(package_path,function_name,sep="infun"){
             variable <- paste0("NumericVector ",arg.name,"(1);","\n",indent,arg.name,"[0]")
             primitives <- c(primitives,arg.name)
           }
-          else if(type.arg == "std::string")
+          else if(type.arg == "std::string" || type.arg == "String")
           {
             variable <- paste0("CharacterVector ",arg.name,"(1);","\n",indent,arg.name,"[0]")
             primitives <- c(primitives,arg.name)
@@ -176,7 +176,7 @@ deepstate_fun_create<-function(package_path,function_name,sep="infun"){
       }
       proto_args <- gsub(" ","",paste0(proto_args,arg.name))
       if(argument.i <= nrow(functions.rows)) {
-        if(type.arg == "int" || type.arg == "double" || type.arg == "std::string"){
+        if(type.arg == "int" || type.arg == "double" || type.arg == "std::string" || type.arg == "String"){
           proto_args <- paste0(proto_args,"[0],")
         }else{
           proto_args <- paste0(proto_args,",")  

--- a/R/get-pkgs.R
+++ b/R/get-pkgs.R
@@ -6,7 +6,7 @@ deepstate_datatype_check <- function(params.list){
   params.list <-gsub("Rcpp::","",params.list)
   params.list <-gsub(" ","",params.list)
 datatypes <- list("NumericVector","NumericMatrix" ,"arma::mat","double",
-                  "string","CharacterVector","int","IntegerVector")
+                  "string", "String","CharacterVector","int","IntegerVector")
 for(pkg.i in seq_along(params.list)){
   #print(params.list[[pkg.i]])
   if(is.element(params.list[[pkg.i]], datatypes) =="FALSE"){

--- a/inst/include/RcppDeepState.h
+++ b/inst/include/RcppDeepState.h
@@ -200,6 +200,14 @@ std::string RcppDeepState_string(){
   return rand_string;
 }
 
+//Rcpp string generation
+Rcpp::String RcppDeepState_String(){
+  std::string rand_string;
+  rand_string = DeepState_CStrUpToLen(50,"abcdefghijklmnopqrstuvwxyz");
+  Rcpp::String rand_rcpp_string(rand_string);
+  return rand_rcpp_string;
+}
+
 //default arma::mat generation
 arma::mat RcppDeepState_mat(){
   int rows = DeepState_IntInRange(1,10);


### PR DESCRIPTION
With this pull request, the `Rcpp::String` datatype has been added to RcppDeepState. Now it is possible to analyze functions that take an argument of type `Rcpp::String`. 

A detailed description of the motivation behind this pull request can be found in the Issue #10.

Fixes #10