### PR TITLE
Harness creation improvements - 3

### DIFF
--- a/R/ci_setup.R
+++ b/R/ci_setup.R
@@ -50,7 +50,7 @@ ci_setup <- function(repository="./", workflow_file_name="RcppDeepState.yaml",
   fail_ci_param <- get_param_yaml("fail_ci_if_error", tolower(fail_ci_if_error))
   location_param <- get_param_yaml("location", location)
   seed_param <- get_param_yaml("seed", seed)
-  time_limit_param <- get_param_yaml("time_limit", time_limit)
+  time_limit_param <- get_param_yaml("max_seconds_per_function", time_limit)
   max_inputs_param <- get_param_yaml("max_inputs", max_inputs)
   comment_param <- get_param_yaml("comment", tolower(comment))
   verbose_param <- get_param_yaml("verbose", tolower(verbose))

--- a/R/ci_setup.R
+++ b/R/ci_setup.R
@@ -86,5 +86,5 @@ indent <- function(times=1){
 # Helper function that generates a string representing a yaml formatted code of
 # a given parameter
 get_param_yaml <- function(param_name, param){
-  paste0(indent(5), param_name, ": '", param, "'")
+  paste0(indent(5), param_name, ": ", param)
 }

--- a/R/fun_harness_create.R
+++ b/R/fun_harness_create.R
@@ -181,13 +181,13 @@ deepstate_fun_create <- function(package_path, function_name, sep="infun"){
     print_values <- paste0(print_values, indent, 'std::cout << "', arg.name,
                            ' values: " << ', arg.name, ' << std::endl; \\\n')    
     
-    proto_args <- gsub(" ", "", paste0(proto_args, arg.name))
     if (type.arg == "string"){
-      proto_args <- paste0("Rcpp::as<std::string>(", proto_args, "[0]),")
+      proto_args <- paste0(proto_args, "Rcpp::as<std::string>(", arg.name, 
+                           "[0]),")
     }else if(!is.na(types_table[type.arg]$rtype)){
-      proto_args <- paste0(proto_args, "[0],")
+      proto_args <- paste0(proto_args, arg.name, "[0],")
     }else{
-      proto_args <- paste0(proto_args, ",")  
+      proto_args <- paste0(proto_args, arg.name, ",")  
     }
 
   }

--- a/R/fun_harness_create.R
+++ b/R/fun_harness_create.R
@@ -182,12 +182,13 @@ deepstate_fun_create <- function(package_path, function_name, sep="infun"){
                            ' values: " << ', arg.name, ' << std::endl; \\\n')    
     
     proto_args <- gsub(" ", "", paste0(proto_args, arg.name))
-    if (!is.na(types_table[type.arg]$rtype)){
+    if (type.arg == "string"){
+      proto_args <- paste0("Rcpp::as<std::string>(",proto_args,"[0]),")
+    }else if(!is.na(types_table[type.arg]$rtype)){
       proto_args <- paste0(proto_args,"[0],")
     }else{
       proto_args <- paste0(proto_args,",")  
     }
-    
 
   }
 

--- a/R/fun_harness_create.R
+++ b/R/fun_harness_create.R
@@ -46,16 +46,16 @@ deepstate_fun_create <- function(package_path, function_name, sep="infun"){
                    "#include <iostream>", "#include <RcppDeepState.h>", 
                    "#include <qs.h>", "#include <DeepState.hpp>\n\n", sep="\n")
   functions.rows  <- functions.list[functions.list$funName == function_name,]
-  params <- gsub(" ","", functions.rows$argument.type)
-  params <- gsub("const","",params)
-  params <- gsub("Rcpp::","",params)
-  params <- gsub("arma::","",params)
-  params <- gsub("std::","",params)
+  params <- gsub(" ", "", functions.rows$argument.type)
+  params <- gsub("const", "", params)
+  params <- gsub("Rcpp::", "", params)
+  params <- gsub("arma::", "", params)
+  params <- gsub("std::", "", params)
 
   filename <- if(sep == "generation" || sep == "checks"){
-    paste0(function_name,"_DeepState_TestHarness_",sep,".cpp")
+    paste0(function_name, "_DeepState_TestHarness_", sep, ".cpp")
   }else{
-    paste0(function_name,"_DeepState_TestHarness.cpp")
+    paste0(function_name, "_DeepState_TestHarness.cpp")
   }
 
   # check if the parameters are allowed or not
@@ -84,18 +84,18 @@ deepstate_fun_create <- function(package_path, function_name, sep="infun"){
 
   if(sep == "generation" || sep == "checks"){
     write_to_file <- paste0(headers)
-    makesep.path <- file.path(fun_path,paste0(sep,".Makefile"))
-    file_path <- file.path(fun_path,filename)
-    file.create(file_path,recursive=TRUE)
-    if(file.exists(file.path(fun_path,"Makefile"))){
-      file.copy(file.path(fun_path,"Makefile"),makesep.path)
+    makesep.path <- file.path(fun_path, paste0(sep, ".Makefile"))
+    file_path <- file.path(fun_path, filename)
+    file.create(file_path, recursive=TRUE)
+    if(file.exists(file.path(fun_path, "Makefile"))){
+      file.copy(file.path(fun_path, "Makefile"), makesep.path)
     }else{
-      deepstate_create_makefile(package_path,function_name)
+      deepstate_create_makefile(package_path, function_name)
     }
 
-    default_harness <- paste0(function_name,"_DeepState_TestHarness")
-    generation_harness <- paste0(function_name,"_DeepState_TestHarness_",sep)
-    makefile_lines <- readLines(file.path(fun_path,"Makefile"),warn=FALSE)
+    default_harness <- paste0(function_name, "_DeepState_TestHarness")
+    generation_harness <- paste0(function_name, "_DeepState_TestHarness_", sep)
+    makefile_lines <- readLines(file.path(fun_path, "Makefile"), warn=FALSE)
     makefile_lines <- gsub(file.path(fun_path, default_harness), 
                            file.path(fun_path, generation_harness), 
                            makefile_lines, fixed=TRUE)
@@ -110,19 +110,19 @@ deepstate_fun_create <- function(package_path, function_name, sep="infun"){
                       "NOT EDIT BY HAND, INSTEAD EDIT\n// ", function_name, 
                       "_DeepState_TestHarness_generation.cpp and ", 
                       function_name, "_DeepState_TestHarness_checks.cpp\n\n")
-    write_to_file <- paste0(comment,headers)
-    file_path <- file.path(fun_path,filename)
-    file.create(file_path,recursive=TRUE)
-    deepstate_create_makefile(package_path,function_name)
+    write_to_file <- paste0(comment, headers)
+    file_path <- file.path(fun_path, filename)
+    file.create(file_path, recursive=TRUE)
+    deepstate_create_makefile(package_path, function_name)
   }
 
   # create a single RInside instance at the beginning
   write_to_file <- paste0(write_to_file, "RInside Rinstance;", "\n\n")  
   write_to_file <- paste0(write_to_file, pt[1,pt$prototype], "\n\n")
   
-  unittest <- gsub(".","", packagename, fixed=TRUE)
-  generator_header <- paste0("\n\n","TEST(",unittest,", generator)","{","\n")
-  runner_header <- paste0("\n\n","TEST(",unittest,", runner)","{","\n")
+  unittest <- gsub(".", "", packagename, fixed=TRUE)
+  generator_header <- paste0("\n\n", "TEST(", unittest, ", generator){", "\n")
+  runner_header <- paste0("\n\n","TEST(",unittest,", runner){", "\n")
 
   # Test harness body
   generation_comment <- if(sep == "generation") "// RANGES CAN BE ADDED HERE\n" 
@@ -133,14 +133,14 @@ deepstate_fun_create <- function(package_path, function_name, sep="infun"){
   print_values <- paste0("\n\n#define PRINT_INPUTS \\\n", indent, 
                          "std::cout << \"input starts\" << std::endl;\\\n")
 
-  proto_args <-""
+  proto_args <- ""
   for(argument.i in 1:nrow(functions.rows)){
-    arg.type <- gsub(" ","",functions.rows [argument.i,argument.type])
-    arg.name <- gsub(" ","",functions.rows [argument.i,argument.name])
-    type.arg <- gsub("const","", arg.type)
-    type.arg <-gsub("Rcpp::","",type.arg)
-    type.arg <-gsub("arma::","",type.arg)
-    type.arg <-gsub("std::","",type.arg)
+    arg.type <- gsub(" ", "", functions.rows[argument.i,argument.type])
+    arg.name <- gsub(" ", "", functions.rows[argument.i,argument.name])
+    type.arg <- gsub("const", "", arg.type)
+    type.arg <-gsub("Rcpp::", "", type.arg)
+    type.arg <-gsub("arma::", "", type.arg)
+    type.arg <-gsub("std::", "", type.arg)
     
     if(sep == "generation" && !is.na(types_table[type.arg]$args)){
       generation_comment <- paste0(generation_comment, "// RcppDeepState_", 
@@ -155,7 +155,7 @@ deepstate_fun_create <- function(package_path, function_name, sep="infun"){
       variable <- paste0(indent, arg.type, " ", arg.name)
     }
     variable <- paste0(variable, "= RcppDeepState_", type.arg, "();", " \\\n")
-    variable <- gsub("const","",variable)
+    variable <- gsub("const", "", variable)
     
     # save the inputs
     inputs_path <- file.path(fun_path, "inputs")
@@ -163,16 +163,16 @@ deepstate_fun_create <- function(package_path, function_name, sep="infun"){
       dir.create(inputs_path)
     }
     if(type.arg == "mat"){
-      input_vals <- file.path(inputs_path,arg.name)
+      input_vals <- file.path(inputs_path, arg.name)
       save_inputs <- paste0("std::ofstream ",  gsub(" ", "", arg.name), 
                             "_stream", ";\n", indent, arg.name, 
                             '_stream.open("', input_vals, '" );\n', indent, 
                             arg.name, '_stream << ', arg.name, ';\n', indent, 
                             arg.name, '_stream.close(); \n')
     }else{
-      input_file <- paste0(arg.name,".qs")
+      input_file <- paste0(arg.name, ".qs")
       input_vals <- file.path(inputs_path, input_file)
-      save_inputs <- paste0('qs::c_qsave(',arg.name, ',"', input_vals, '",\n',
+      save_inputs <- paste0('qs::c_qsave(', arg.name, ',"', input_vals, '",\n',
                             '\t\t"high", "zstd", 1, 15, true, 1);\n')
     }
 
@@ -183,11 +183,11 @@ deepstate_fun_create <- function(package_path, function_name, sep="infun"){
     
     proto_args <- gsub(" ", "", paste0(proto_args, arg.name))
     if (type.arg == "string"){
-      proto_args <- paste0("Rcpp::as<std::string>(",proto_args,"[0]),")
+      proto_args <- paste0("Rcpp::as<std::string>(", proto_args, "[0]),")
     }else if(!is.na(types_table[type.arg]$rtype)){
-      proto_args <- paste0(proto_args,"[0],")
+      proto_args <- paste0(proto_args, "[0],")
     }else{
-      proto_args <- paste0(proto_args,",")  
+      proto_args <- paste0(proto_args, ",")  
     }
 
   }
@@ -200,7 +200,7 @@ deepstate_fun_create <- function(package_path, function_name, sep="infun"){
   runner_body <- paste0(indent, "INPUTS\n", indent,"PRINT_INPUTS\n",inputs_dump)
 
   runner_body <- paste0(runner_body, indent, "try{\n", indent, indent, 
-                        function_name, "(", gsub(",$","",proto_args), ");\n")
+                        function_name, "(", gsub(",$", "", proto_args), ");\n")
   if(sep == "checks"){
     assert_comment <- "//ASSERT CONDITIONS CAN BE ADDED HERE\n"
     runner_body <- paste0(runner_body, indent, indent, assert_comment) 
@@ -209,11 +209,11 @@ deepstate_fun_create <- function(package_path, function_name, sep="infun"){
                         indent, indent, 'std::cout<<"Exception Handled"', 
                         "<<std::endl;\n", indent, "}")
   
-  write_to_file<-paste0(write_to_file, generation_comment, inputs, print_values, 
-                        generator_header, generator_body, "}", runner_header, 
-                        runner_body, "\n}")
+  write_to_file <- paste0(write_to_file, generation_comment, inputs, 
+                          print_values, generator_header, generator_body, "}", 
+                          runner_header, runner_body, "\n}")
                         
-  write(write_to_file,file_path,append=TRUE)
+  write(write_to_file, file_path, append=TRUE)
 
   return(filename)
 }

--- a/R/fun_harness_create.R
+++ b/R/fun_harness_create.R
@@ -182,15 +182,12 @@ deepstate_fun_create <- function(package_path, function_name, sep="infun"){
                            ' values: " << ', arg.name, ' << std::endl; \\\n')    
     
     proto_args <- gsub(" ", "", paste0(proto_args, arg.name))
-    if(argument.i <= nrow(functions.rows)) {
-      if(type.arg == "int" || type.arg == "double"){
-        proto_args <- paste0(proto_args,"[0],")
-      }else if(type.arg == "string"){
-        proto_args <- paste0("Rcpp::as<std::string>(",proto_args,"[0]),")
-      }else{
-        proto_args <- paste0(proto_args,",")  
-      }
+    if (!is.na(types_table[type.arg]$rtype)){
+      proto_args <- paste0(proto_args,"[0],")
+    }else{
+      proto_args <- paste0(proto_args,",")  
     }
+    
 
   }
 


### PR DESCRIPTION
This pull request improves the test harness creation procedure. These changes amount to:
* solve the issue that happens when a function takes a `std::string` as an input. This issue was caused by the incorrect placement of  `Rcpp::as<std::string>` in the harness file;
* code refactoring.