### PR TITLE
Makevars issue

### DIFF
--- a/R/pkg_harness_create.R
+++ b/R/pkg_harness_create.R
@@ -44,7 +44,6 @@ deepstate_pkg_create <- function(package_path, verbose=getOption("verbose")) {
 
     system(paste0("R CMD INSTALL ", package_path), intern=FALSE,
            ignore.stdout=!verbose, ignore.stderr=!verbose)
-    unlink(makevars_file, recursive = FALSE)
   }
 
   # download and build deepstate

--- a/R/pkg_harness_create.R
+++ b/R/pkg_harness_create.R
@@ -38,7 +38,7 @@ deepstate_pkg_create <- function(package_path, verbose=getOption("verbose")) {
     # ensure that the debugging symbols are embedded in the shared object
     makevars_file <- file.path(package_path, "src", "Makevars")
     if (dir.exists(file.path(package_path, "src"))) {
-        makevars_content <- "PKG_CXXFLAGS += -g "
+        makevars_content <- "PKG_CXXFLAGS += -g \n"
         write(makevars_content, makevars_file, append=TRUE)
     }
 

--- a/R/pkg_harness_create.R
+++ b/R/pkg_harness_create.R
@@ -39,7 +39,7 @@ deepstate_pkg_create <- function(package_path, verbose=getOption("verbose")) {
     makevars_file <- file.path(package_path, "src", "Makevars")
     if (dir.exists(file.path(package_path, "src"))) {
         makevars_content <- "PKG_CXXFLAGS += -g "
-        write(makevars_content, makevars_file, append=FALSE)
+        write(makevars_content, makevars_file, append=TRUE)
     }
 
     system(paste0("R CMD INSTALL ", package_path), intern=FALSE,


### PR DESCRIPTION
## Description
I discovered a problem with a package that I was trying to analyze with RcppDeepState. This package has a peculiarity: an existing `Makevars` file inside the `src` folder. Running RcppDeepState on this package gave me a linker error; certain files in the `src` folder included a library from `inst/include`. This library was not included during the compilation process, resulting in the following error: 
```bash
discord.cpp:4:10: fatal error: jmotif.h: No such file or directory
    4 | #include <jmotif.h>
```

## The Issue
I found that the issue was caused by RcppDeepState that overwrites the default `Makevars` file with a flag to include debug symbols in the compiled shared object file(`PKG_CXXFLAGS += -g`).

## Solution
The solution is to modify the mechanism that creates the `Makevars` file within the package's `src` folder. If a package already has a `Makevars` file, it should not be overwritten with the new one, which contains the `-g` flag for debugging symbols. 