### PR TITLE
Dependencies problem

### DIFF
--- a/R/fun_makefile_create.R
+++ b/R/fun_makefile_create.R
@@ -80,6 +80,7 @@ deepstate_create_makefile <-function(package,fun_name){
     dir.create(inputs_path)
   }
 
+  # install the package in order to install with its dependencies from CRAN
   install.packages(setdiff(basename(package), rownames(installed.packages())),
                            repos = "http://cran.us.r-project.org")
   

--- a/R/fun_makefile_create.R
+++ b/R/fun_makefile_create.R
@@ -79,5 +79,8 @@ deepstate_create_makefile <-function(package,fun_name){
   if(!dir.exists(inputs_path)){
     dir.create(inputs_path)
   }
+
+  install.packages(setdiff(basename(package), rownames(installed.packages())),
+                           repos = "http://cran.us.r-project.org")
   
 }


### PR DESCRIPTION
### Description of the issue
While running RcppDeepState on the `hermiter` pacakge, it reported me this strange error:
```
 /github/workspace/src/hermite_utils.cpp:4:10: fatal error: 'RcppParallel.h' file not found
#include <RcppParallel.h>
         ^~~~~~~~~~~~~~~~
``` 
This appears to be the result of the package's dependencies not being installed properly.

### Solution
Installing the package from CRAN once the makefiles have been generated for it would solve this problem. 